### PR TITLE
Add a DuckDB-Wasm integration + demo application

### DIFF
--- a/demo/malloy-demo-browser/index.html
+++ b/demo/malloy-demo-browser/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Malloy</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/demo/malloy-demo-browser/package.json
+++ b/demo/malloy-demo-browser/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "malloy-demo-browser",
+  "private": true,
+  "version": "0.0.0",
+  "scripts": {
+    "build": "tsc && vite build",
+    "dev": "vite",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@duckdb/duckdb-wasm": "^1.16.0",
+    "@malloydata/db-duckdb-wasm": "^0.0.1",
+    "highlight.js": "^11.6.0",
+    "prettier": "^2.6.2",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.0",
+    "@types/react-dom": "^18.0.0",
+    "@vitejs/plugin-react": "^1.3.0",
+    "autoprefixer": "^10.4.7",
+    "postcss": "^8.4.14",
+    "tailwindcss": "^3.0.24",
+    "typescript": "^4.6.3",
+    "vite": "^2.9.9"
+  }
+}

--- a/demo/malloy-demo-browser/postcss.config.js
+++ b/demo/malloy-demo-browser/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/demo/malloy-demo-browser/src/App.tsx
+++ b/demo/malloy-demo-browser/src/App.tsx
@@ -1,0 +1,59 @@
+import hljs from "highlight.js";
+import "highlight.js/styles/github.css";
+import { useState } from "react";
+import Label from "./Components/Label";
+import Selector from "./Components/Selector";
+import { GEOGRAPHY_TO_QUERY, MODEL } from "./data";
+import { useConnections, useModel } from "./hooks";
+import { Geography } from "./types";
+
+export default function App() {
+  const connections = useConnections();
+  const model = useModel(MODEL, connections);
+
+  const [geography, setGeography] = useState<Geography>("Georgia");
+
+  if (model == null) {
+    return (
+      <div className={"w-screen h-screen flex justify-center items-center"}>
+        Loading...
+      </div>
+    );
+  }
+
+  const { sql } = model.getPreparedQueryByName(
+    GEOGRAPHY_TO_QUERY[geography]
+  ).preparedResult;
+
+  return (
+    <div className={"text-xs flex flex-row w-screen h-screen p-4"}>
+      <div className={"w-1/2 mr-2 p-4 rounded border border-slate-300"}>
+        <pre className={"w-full h-full overflow-scroll relative"}>
+          <div className={"absolute top-0 right-0"}>
+            <Label>Malloy</Label>
+          </div>
+          <code
+            dangerouslySetInnerHTML={{
+              __html: hljs.highlight("sql", MODEL).value,
+            }}
+          />
+        </pre>
+      </div>
+      <div className={"w-1/2 ml-2 p-4 rounded border border-slate-300"}>
+        <pre className={"w-full h-full overflow-scroll relative hljs"}>
+          <div className={"absolute top-0 right-0"}>
+            <Label>SQL</Label>
+          </div>
+          <div className={"absolute top-8 right-0"}>
+            <Selector selected={geography} onChange={setGeography} />
+          </div>
+          <code
+            dangerouslySetInnerHTML={{
+              __html: hljs.highlight(sql, { language: "sql" }).value,
+            }}
+          />
+        </pre>
+      </div>
+    </div>
+  );
+}

--- a/demo/malloy-demo-browser/src/Components/Label.tsx
+++ b/demo/malloy-demo-browser/src/Components/Label.tsx
@@ -1,0 +1,9 @@
+import { ReactNode } from "react";
+
+export default function Label({ children }: { children: ReactNode }) {
+  return (
+    <div className={"bg-slate-100 px-2 py-1 rounded text-slate-800"}>
+      {children}
+    </div>
+  );
+}

--- a/demo/malloy-demo-browser/src/Components/Selector.tsx
+++ b/demo/malloy-demo-browser/src/Components/Selector.tsx
@@ -1,0 +1,28 @@
+import { Geography } from "../types";
+
+const ALL_GEOGRAPHIES: Geography[] = ["Georgia", "Pennsylvania"];
+
+export default function Selector({
+  selected,
+  onChange,
+}: {
+  selected: Geography;
+  onChange: (selected: Geography) => void;
+}) {
+  return (
+    <div className={"flex flex-row"}>
+      {ALL_GEOGRAPHIES.map((geography) => (
+        <button
+          key={geography}
+          className={
+            "bg-slate-100 px-2 mr-2 py-1 rounded hover:text-slate-800 " +
+            (selected === geography ? "text-slate-800" : "text-slate-300")
+          }
+          onClick={() => onChange(geography)}
+        >
+          {geography}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/demo/malloy-demo-browser/src/compile.ts
+++ b/demo/malloy-demo-browser/src/compile.ts
@@ -1,0 +1,48 @@
+import { DuckDBWasmConnection } from "@malloydata/db-duckdb-wasm/src";
+import {
+  Connection,
+  FixedConnectionMap,
+  LookupConnection,
+  Malloy,
+  Model,
+  PreparedResult,
+  Result,
+  URLReader,
+} from "@malloydata/malloy/src";
+
+class DummyFiles implements URLReader {
+  async readURL(): Promise<string> {
+    return "";
+  }
+}
+
+export async function initializeConnections(): Promise<
+  LookupConnection<Connection>
+> {
+  const connection = new DuckDBWasmConnection("duckdb-wasm");
+  return new FixedConnectionMap(
+    new Map([["duckdb-wasm", connection]]),
+    "duckdb-wasm"
+  );
+}
+
+export async function compileModel(
+  source: string,
+  connections: LookupConnection<Connection>
+): Promise<Model> {
+  return await Malloy.compile({
+    urlReader: new DummyFiles(),
+    connections,
+    parse: Malloy.parse({ source }),
+  });
+}
+
+export async function runQuery(
+  preparedResult: PreparedResult,
+  connections: LookupConnection<Connection>
+): Promise<Result> {
+  return await Malloy.run({
+    connections,
+    preparedResult,
+  });
+}

--- a/demo/malloy-demo-browser/src/data.ts
+++ b/demo/malloy-demo-browser/src/data.ts
@@ -1,0 +1,60 @@
+import { Geography } from "./types";
+
+export const GEOGRAPHY_TO_QUERY: { [K in Geography]: string } = {
+  Georgia: "georgia_dashboard",
+  Pennsylvania: "pennsylvania_dashboard",
+};
+
+export const MODEL = `source: political_ads is table('duckdb-wasm:https://sql-cached-artifact-api.anomander.xyz/artifacts/political-spend-big/31353222-8a65-4d62-87cb-e60415390413.parquet') {
+  measure:
+    total_spend is sum((spend_range_max_usd))
+    percent_of_spend is total_spend/all(total_spend) * 100
+    ad_count is count(distinct ad_id)
+
+  query: top_ads is {
+    group_by:
+      start is date_range_start
+      ad_type
+      ad_url
+    aggregate:
+      total_spend
+      percent_of_spend
+    group_by: relevant_geos
+    order_by: total_spend desc
+  }
+
+  query: spend_dashboard is {
+    top: 20
+    group_by: advertiser_name
+    aggregate:
+      spend_30_days is total_spend {
+        where: date_range_start = now - 30 days for 30 days
+      }
+      lifetime_spend is total_spend
+      lifetime_ad_count is ad_count
+    nest: spend_over_time_line_chart is {
+      group_by: start_week is date_range_start.week
+      aggregate: total_spend
+    }
+    nest: by_media_type_bar_chart is {
+      group_by: ad_type
+      aggregate: total_spend, ad_count
+      order_by: ad_type
+    }
+    nest: recent_ads is top_ads {
+      where: date_range_start = now - 30 days for 30 days
+      limit: 5
+    }
+    nest: top_lifetime_spend is top_ads {
+      limit: 5
+    }
+  }
+}
+
+query: pennsylvania_dashboard is political_ads-> spend_dashboard {
+  where: relevant_geos ~r'Pennsylvania'
+}
+
+query: georgia_dashboard is political_ads-> spend_dashboard {
+  where: relevant_geos ~r'Georgia'
+}`;

--- a/demo/malloy-demo-browser/src/hooks.ts
+++ b/demo/malloy-demo-browser/src/hooks.ts
@@ -1,0 +1,50 @@
+import {
+  Connection,
+  LookupConnection,
+  Model,
+  Result,
+} from "@malloydata/malloy";
+import { useEffect, useState } from "react";
+import { compileModel, initializeConnections, runQuery } from "./compile";
+
+export function useConnections(): LookupConnection<Connection> | undefined {
+  const [connections, setConnections] =
+    useState<LookupConnection<Connection>>();
+
+  useEffect(() => {
+    initializeConnections().then(setConnections);
+  }, []);
+
+  return connections;
+}
+
+export function useModel(
+  source: string,
+  connections?: LookupConnection<Connection>
+): Model | undefined {
+  const [model, setModel] = useState<Model>();
+
+  useEffect(() => {
+    if (connections == null) return;
+    compileModel(source, connections).then(setModel);
+  }, [source, connections]);
+
+  return model;
+}
+
+export function useResult(
+  model?: Model,
+  queryName?: string,
+  connections?: LookupConnection<Connection>
+): Result | undefined {
+  const [result, setResult] = useState<Result>();
+
+  useEffect(() => {
+    if (model == null || queryName == null || connections == null) return;
+    const preparedResult =
+      model.getPreparedQueryByName(queryName).preparedResult;
+    runQuery(preparedResult, connections).then(setResult);
+  }, [model, queryName, connections]);
+
+  return result;
+}

--- a/demo/malloy-demo-browser/src/index.css
+++ b/demo/malloy-demo-browser/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/demo/malloy-demo-browser/src/main.tsx
+++ b/demo/malloy-demo-browser/src/main.tsx
@@ -1,0 +1,6 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App";
+import "./index.css";
+
+ReactDOM.createRoot(document.getElementById("root")!).render(<App />);

--- a/demo/malloy-demo-browser/src/types.ts
+++ b/demo/malloy-demo-browser/src/types.ts
@@ -1,0 +1,1 @@
+export type Geography = "Georgia" | "Pennsylvania";

--- a/demo/malloy-demo-browser/src/vite-env.d.ts
+++ b/demo/malloy-demo-browser/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/demo/malloy-demo-browser/tailwind.config.js
+++ b/demo/malloy-demo-browser/tailwind.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ["./index.html", "./src/**/*.{vue,js,ts,jsx,tsx}"],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/demo/malloy-demo-browser/tsconfig.json
+++ b/demo/malloy-demo-browser/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": [
+      "src"
+  ],
+  "references": [{ "path": "./tsconfig.node.json"}]
+}

--- a/demo/malloy-demo-browser/tsconfig.node.json
+++ b/demo/malloy-demo-browser/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "esnext",
+    "moduleResolution": "node"
+  },
+  "include": [
+      "vite.config.ts"
+  ]
+}

--- a/demo/malloy-demo-browser/vite.config.ts
+++ b/demo/malloy-demo-browser/vite.config.ts
@@ -1,0 +1,9 @@
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [react()],
+  define: {
+    "process.env": {},
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,6 +65,78 @@
         "malloy-demo-bq-cli": "dist/entry.js"
       }
     },
+    "demo/malloy-demo-browser": {
+      "version": "0.0.0",
+      "dependencies": {
+        "@duckdb/duckdb-wasm": "^1.16.0",
+        "@malloydata/db-duckdb-wasm": "^0.0.1",
+        "highlight.js": "^11.6.0",
+        "prettier": "^2.6.2",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      },
+      "devDependencies": {
+        "@types/react": "^18.0.0",
+        "@types/react-dom": "^18.0.0",
+        "@vitejs/plugin-react": "^1.3.0",
+        "autoprefixer": "^10.4.7",
+        "postcss": "^8.4.14",
+        "tailwindcss": "^3.0.24",
+        "typescript": "^4.6.3",
+        "vite": "^2.9.9"
+      }
+    },
+    "demo/malloy-demo-browser/node_modules/@types/react": {
+      "version": "18.0.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.17.tgz",
+      "integrity": "sha512-38ETy4tL+rn4uQQi7mB81G7V1g0u2ryquNmsVIOKUAEIDK+3CUjZ6rSRpdvS99dNBnkLFL83qfmtLacGOTIhwQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "demo/malloy-demo-browser/node_modules/@types/react-dom": {
+      "version": "18.0.6",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.6.tgz",
+      "integrity": "sha512-/5OFZgfIPSwy+YuIBP/FgJnQnsxhZhjjrnxudMddeblOouIodEQ75X14Rr4wGSG/bknL+Omy9iWlLo1u/9GzAA==",
+      "dev": true,
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "demo/malloy-demo-browser/node_modules/react": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "demo/malloy-demo-browser/node_modules/react-dom": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
+      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.0"
+      },
+      "peerDependencies": {
+        "react": "^18.2.0"
+      }
+    },
+    "demo/malloy-demo-browser/node_modules/scheduler": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
+      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
     "demo/malloy-demo-composer": {
       "name": "malloy-composer-demo",
       "version": "0.1.0",
@@ -532,6 +604,21 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-syntax-jsx": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.18.6.tgz",
+      "integrity": "sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.18.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
@@ -611,6 +698,70 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx": {
+      "version": "7.18.10",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.18.10.tgz",
+      "integrity": "sha512-gCy7Iikrpu3IZjYZolFE4M1Sm+nrh1/6za2Ewj77Z+XirT4TsbJcvOFOyF+fRPwU6AKKK136CZxx6L8AbSFG6A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.18.6",
+        "@babel/helper-module-imports": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.18.9",
+        "@babel/plugin-syntax-jsx": "^7.18.6",
+        "@babel/types": "^7.18.10"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-development": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.18.6.tgz",
+      "integrity": "sha512-SA6HEjwYFKF7WDjWcMcMGUimmw/nhNRDWxr+KaLSCrkD/LMDBvWRmHAYgE1HDeF8KUuI8OAu+RT6EOtKxSW2qA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/plugin-transform-react-jsx": "^7.18.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.18.6.tgz",
+      "integrity": "sha512-A0LQGx4+4Jv7u/tWzoJF7alZwnBDQd6cGLh9P+Ttk4dpiL+J5p7NSNv/9tlEFFJDq3kjxOavWmbm6t0Gk+A3Ig==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.18.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.18.6.tgz",
+      "integrity": "sha512-utZmlASneDfdaMh0m/WausbjUjEdGrQJz0vFK93d7wD3xf5wBtX219+q6IlCNZeguIcxS2f/CvLZrlLSvSHQXw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -748,6 +899,14 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@duckdb/duckdb-wasm": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@duckdb/duckdb-wasm/-/duckdb-wasm-1.16.0.tgz",
+      "integrity": "sha512-6jacKFUQEgfqF+rYyuIg/hwdSAxIfN4Xyl1cNBHqm4/V/C09JL07rx/ljeURvLVx/hWYD3IwyQAnLfxP/8o5Og==",
+      "dependencies": {
+        "apache-arrow": "^8.0.0"
       }
     },
     "node_modules/@electron/get": {
@@ -1360,6 +1519,10 @@
       "resolved": "packages/malloy-db-duckdb",
       "link": true
     },
+    "node_modules/@malloydata/db-duckdb-wasm": {
+      "resolved": "packages/malloy-db-duckdb-wasm",
+      "link": true
+    },
     "node_modules/@malloydata/db-postgres": {
       "resolved": "packages/malloy-db-postgres",
       "link": true
@@ -1553,6 +1716,19 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
+      "integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
+      "dev": true,
+      "dependencies": {
+        "estree-walker": "^2.0.1",
+        "picomatch": "^2.2.2"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
       }
     },
     "node_modules/@sideway/address": {
@@ -1929,6 +2105,16 @@
       "resolved": "https://registry.npmjs.org/@types/clone/-/clone-2.1.1.tgz",
       "integrity": "sha512-BZIU34bSYye0j/BFcPraiDZ5ka6MJADjcDVELGf7glr9K+iE8NYVjFslJFVWzskSxkLLyCrSPScE82/UUoBSvg=="
     },
+    "node_modules/@types/command-line-args": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@types/command-line-args/-/command-line-args-5.2.0.tgz",
+      "integrity": "sha512-UuKzKpJJ/Ief6ufIaIzr3A/0XnluX7RvFgwkV89Yzvm77wCh1kFaFmqN8XEnGcN62EuHdedQjEMb8mYxFLGPyA=="
+    },
+    "node_modules/@types/command-line-usage": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@types/command-line-usage/-/command-line-usage-5.0.2.tgz",
+      "integrity": "sha512-n7RlEEJ+4x4TS7ZQddTmNSxP+zziEG0TNsMfiRIxcIVXt71ENJ9ojeXmGO3wPoTdn7pJcU2xc3CJYMktNT6DPg=="
+    },
     "node_modules/@types/debug": {
       "version": "4.1.7",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
@@ -1941,6 +2127,11 @@
       "version": "0.0.50",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz",
       "integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw=="
+    },
+    "node_modules/@types/flatbuffers": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@types/flatbuffers/-/flatbuffers-1.10.0.tgz",
+      "integrity": "sha512-7btbphLrKvo5yl/5CC2OCxUSMx1wV1wvGT1qDXkSt7yi00/YW7E8k6qzXqJHsp+WU0eoG7r6MTQQXI9lIvd0qA=="
     },
     "node_modules/@types/fs-extra": {
       "version": "9.0.13",
@@ -2113,6 +2304,11 @@
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
       "dev": true
+    },
+    "node_modules/@types/pad-left": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@types/pad-left/-/pad-left-2.1.1.tgz",
+      "integrity": "sha512-Xd22WCRBydkGSApl5Bw0PhAOHKSVjNL3E3AwzKaps96IMraPqy5BvZIsBVK6JLwdybUzjHnuWVwpDd0JjTfHXA=="
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
@@ -2429,6 +2625,25 @@
       "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
       "dev": true
     },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-1.3.2.tgz",
+      "integrity": "sha512-aurBNmMo0kz1O4qRoY+FM4epSA39y3ShWGuqfLRA/3z0oEJAdtoSfgA3aO98/PCCHAqMaduLxIxErWrVKIFzXA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.17.10",
+        "@babel/plugin-transform-react-jsx": "^7.17.3",
+        "@babel/plugin-transform-react-jsx-development": "^7.16.7",
+        "@babel/plugin-transform-react-jsx-self": "^7.16.7",
+        "@babel/plugin-transform-react-jsx-source": "^7.16.7",
+        "@rollup/pluginutils": "^4.2.1",
+        "react-refresh": "^0.13.0",
+        "resolve": "^1.22.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/@vscode/webview-ui-toolkit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@vscode/webview-ui-toolkit/-/webview-ui-toolkit-1.0.0.tgz",
@@ -2493,6 +2708,17 @@
       "dev": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/acorn-node": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/acorn-node/-/acorn-node-1.8.2.tgz",
+      "integrity": "sha512-8mt+fslDufLYntIoPAaIMUe/lrbrehIiwmR3t2k9LljIzoigEPF27eLk2hy8zSGzmR/ogr7zbRKINMo1u0yh5A==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^7.0.0",
+        "acorn-walk": "^7.0.0",
+        "xtend": "^4.0.2"
       }
     },
     "node_modules/acorn-walk": {
@@ -2614,6 +2840,37 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/apache-arrow": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/apache-arrow/-/apache-arrow-8.0.0.tgz",
+      "integrity": "sha512-74wgHL9P+vgylNOhnLGw1meOQ1cbYyi+TXo1eDnQJ9g2Ly+k8novUWQIG5SIp6acnErhGRTsMJajwUh9x/ZbaQ==",
+      "dependencies": {
+        "@types/command-line-args": "5.2.0",
+        "@types/command-line-usage": "5.0.2",
+        "@types/flatbuffers": "*",
+        "@types/node": "^17.0.24",
+        "@types/pad-left": "2.1.1",
+        "command-line-args": "5.2.1",
+        "command-line-usage": "6.1.3",
+        "flatbuffers": "2.0.4",
+        "json-bignum": "^0.0.3",
+        "pad-left": "^2.1.0",
+        "tslib": "^2.3.1"
+      },
+      "bin": {
+        "arrow2csv": "bin/arrow2csv.js"
+      }
+    },
+    "node_modules/apache-arrow/node_modules/@types/node": {
+      "version": "17.0.45",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
+      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw=="
+    },
+    "node_modules/apache-arrow/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/aproba": {
       "version": "1.2.0",
@@ -2754,6 +3011,14 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/array-back": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
+      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/array-flat-polyfill": {
@@ -2904,6 +3169,39 @@
       "devOptional": true,
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/autoprefixer": {
+      "version": "10.4.8",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.8.tgz",
+      "integrity": "sha512-75Jr6Q/XpTqEf6D2ltS5uMewJIx5irCU1oBYJrWjFenq/m12WRRrz6g15L1EIoYvPLXTbEry7rDOwrcYNj77xw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        }
+      ],
+      "dependencies": {
+        "browserslist": "^4.21.3",
+        "caniuse-lite": "^1.0.30001373",
+        "fraction.js": "^4.2.0",
+        "normalize-range": "^0.1.2",
+        "picocolors": "^1.0.0",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
       }
     },
     "node_modules/available-typed-arrays": {
@@ -3510,6 +3808,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/camelcase-css": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/camelize": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.0.tgz",
@@ -3980,6 +4287,114 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/command-line-args": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.2.1.tgz",
+      "integrity": "sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==",
+      "dependencies": {
+        "array-back": "^3.1.0",
+        "find-replace": "^3.0.0",
+        "lodash.camelcase": "^4.3.0",
+        "typical": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/command-line-usage": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-6.1.3.tgz",
+      "integrity": "sha512-sH5ZSPr+7UStsloltmDh7Ce5fb8XPlHyoPzTpyyMuYCtervL65+ubVZ6Q61cFtFl62UyJlc8/JwERRbAFPUqgw==",
+      "dependencies": {
+        "array-back": "^4.0.2",
+        "chalk": "^2.4.2",
+        "table-layout": "^1.0.2",
+        "typical": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/array-back": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
+      "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+    },
+    "node_modules/command-line-usage/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/typical": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+      "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -4278,6 +4693,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/cssom": {
@@ -4793,6 +5220,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/defined": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+      "integrity": "sha512-Y2caI5+ZwS5c3RiNDJ6u53VhQHv+hHKwhkI1iHvceKUHw9Df6EK2zRLfjejRgMuCuxK7PfSWIMwWecceVvThjQ==",
+      "dev": true
+    },
     "node_modules/delaunator": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-4.0.1.tgz",
@@ -4843,6 +5276,29 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
+    },
+    "node_modules/detective": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/detective/-/detective-5.2.1.tgz",
+      "integrity": "sha512-v9XE1zRnz1wRtgurGu0Bs8uHKFSTdteYZNbIPFVhUZ39L/S79ppMpdmVOZAnoz1jfEFodc48n6MX483Xo3t1yw==",
+      "dev": true,
+      "dependencies": {
+        "acorn-node": "^1.8.2",
+        "defined": "^1.0.0",
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "detective": "bin/detective.js"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/didyoumean": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
+      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+      "dev": true
     },
     "node_modules/diff": {
       "version": "5.0.0",
@@ -4911,6 +5367,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dlv": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true
     },
     "node_modules/doctrine": {
       "version": "3.0.0",
@@ -6308,6 +6770,12 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -6825,6 +7293,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/find-replace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
+      "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
+      "dependencies": {
+        "array-back": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -6859,6 +7338,11 @@
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
       }
+    },
+    "node_modules/flatbuffers": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-2.0.4.tgz",
+      "integrity": "sha512-4rUFVDPjSoP0tOII34oQf+72NKU7E088U5oX7kwICahft0UB2kOQ9wUzzCp+OHxByERIfxRDCgX5mP8Pjkfl0g=="
     },
     "node_modules/flatted": {
       "version": "3.2.6",
@@ -6959,6 +7443,19 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/fraction.js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.2.0.tgz",
+      "integrity": "sha512-MhLuK+2gUcnZe8ZHlaaINnQLl0xRIGRfcGk2yl8xoQAfHrSsL3rYu6FCmBdkdbhc9EPlwyGHewaRsvwRMJtAlA==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/infusion"
       }
     },
     "node_modules/fragment-cache": {
@@ -7858,6 +8355,14 @@
       "dev": true,
       "bin": {
         "he": "bin/he"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "11.6.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.6.0.tgz",
+      "integrity": "sha512-ig1eqDzJaB0pqEvlPVIpSSyMaO92bH1N2rJpLMN/nX396wTpDA4Eq0uK+7I/2XG17pFaaKE0kjV/XPeGt7Evjw==",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/hoist-non-react-statics": {
@@ -10113,6 +10618,14 @@
         "bignumber.js": "^9.0.0"
       }
     },
+    "node_modules/json-bignum": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/json-bignum/-/json-bignum-0.0.3.tgz",
+      "integrity": "sha512-2WHyXj3OfHSgNyuzDbSxI1w2jgw5gkWSWhS7Qg4bWXx1nLk3jnbwfUeS0PSba3IzpTUWdHxBieELUzXRjQB2zg==",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
@@ -10324,6 +10837,15 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lilconfig": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.6.tgz",
+      "integrity": "sha512-9JROoBW7pobfsx+Sq2JsASvCo6Pfo6WWoUW79HuB1BCoBXD4PLWJPqDF6fNj67pqBYTbAHkE57M1kS/+L1neOg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -10406,6 +10928,11 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
     },
     "node_modules/lodash.defaults": {
       "version": "4.2.0",
@@ -10562,6 +11089,10 @@
     },
     "node_modules/malloy-demo-bq-cli": {
       "resolved": "demo/malloy-demo-bq-cli",
+      "link": true
+    },
+    "node_modules/malloy-demo-browser": {
+      "resolved": "demo/malloy-demo-browser",
       "link": true
     },
     "node_modules/map-cache": {
@@ -12234,6 +12765,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/normalize-range": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+      "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/normalize-url": {
       "version": "4.5.1",
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
@@ -12403,6 +12943,15 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/object-inspect": {
@@ -12615,6 +13164,17 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-1.0.0.tgz",
       "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ=="
+    },
+    "node_modules/pad-left": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pad-left/-/pad-left-2.1.0.tgz",
+      "integrity": "sha512-HJxs9K9AztdIQIAIa/OIazRAUW/L6B9hbQDxO4X07roW3eo9XqZc2ur9bn1StH9CnbbI9EgvejHQX7CBpCF1QA==",
+      "dependencies": {
+        "repeat-string": "^1.5.4"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -12977,10 +13537,143 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/postcss": {
+      "version": "8.4.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.16.tgz",
+      "integrity": "sha512-ipHE1XBvKzm5xI7hiHCZJCSugxvsdq2mPnsq5+UF+VHCjiBvtDrlxJfMBToWaP9D5XlgNmcFGqoHmUn0EYEaRQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.4",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-import": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-14.1.0.tgz",
+      "integrity": "sha512-flwI+Vgm4SElObFVPpTIT7SU7R3qk2L7PyduMcokiaVKuWv9d/U+Gm/QAd8NDLuykTWTkcrjOeD2Pp1rMeBTGw==",
+      "dev": true,
+      "dependencies": {
+        "postcss-value-parser": "^4.0.0",
+        "read-cache": "^1.0.0",
+        "resolve": "^1.1.7"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.0"
+      }
+    },
+    "node_modules/postcss-js": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.0.0.tgz",
+      "integrity": "sha512-77QESFBwgX4irogGVPgQ5s07vLvFqWr228qZY+w6lW599cRlK/HmnlivnnVUxkjHnCu4J16PDMHcH+e+2HbvTQ==",
+      "dev": true,
+      "dependencies": {
+        "camelcase-css": "^2.0.1"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >= 16"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      },
+      "peerDependencies": {
+        "postcss": "^8.3.3"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-3.1.4.tgz",
+      "integrity": "sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==",
+      "dev": true,
+      "dependencies": {
+        "lilconfig": "^2.0.5",
+        "yaml": "^1.10.2"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      },
+      "peerDependencies": {
+        "postcss": ">=8.0.9",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "postcss": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/postcss-nested": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-5.0.6.tgz",
+      "integrity": "sha512-rKqm2Fk0KbA8Vt3AdGN0FB9OBOMDVajMG6ZCf/GoHgdxUJ4sBFp0A/uMIRm+MJUdo33YXEtjqIz8u7DAp8B7DA==",
+      "dev": true,
+      "dependencies": {
+        "postcss-selector-parser": "^6.0.6"
+      },
+      "engines": {
+        "node": ">=12.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.14"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "dev": true,
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/postcss-value-parser": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
+    },
+    "node_modules/postcss/node_modules/nanoid": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+      "dev": true,
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
     },
     "node_modules/postgres-array": {
       "version": "2.0.0",
@@ -13064,7 +13757,6 @@
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
       "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
-      "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -13245,6 +13937,18 @@
         }
       ]
     },
+    "node_modules/quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -13387,6 +14091,15 @@
         }
       }
     },
+    "node_modules/react-refresh": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.13.0.tgz",
+      "integrity": "sha512-XP8A9BT0CpRBD+NYLLeIhld/RqG9+gktUjW1FkE+Vm7OCinbG1SshcK5tb9ls4kzvjZr9mOQc7HYgBngEyPAXg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/read": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
@@ -13397,6 +14110,24 @@
       },
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/read-cache": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "dev": true,
+      "dependencies": {
+        "pify": "^2.3.0"
+      }
+    },
+    "node_modules/read-cache/node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/read-pkg": {
@@ -13502,6 +14233,14 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/reduce-flatten": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-2.0.0.tgz",
+      "integrity": "sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/regenerator-runtime": {
@@ -13617,7 +14356,6 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
-      "dev": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -13846,6 +14584,21 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
       "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
       "optional": true
+    },
+    "node_modules/rollup": {
+      "version": "2.77.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.77.3.tgz",
+      "integrity": "sha512-/qxNTG7FbmefJWoeeYJFbHehJ2HNWnjkAFRKzWN/45eNBBF/r8lo992CwcJXEzyVxs5FmfId+vTSTQDb+bxA+g==",
+      "dev": true,
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
     },
     "node_modules/rsvp": {
       "version": "4.8.5",
@@ -14687,6 +15440,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/source-map-js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-resolve": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
@@ -15261,6 +16023,36 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/table-layout": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-1.0.2.tgz",
+      "integrity": "sha512-qd/R7n5rQTRFi+Zf2sk5XVVd9UQl6ZkduPFC3S7WEGJAmetDTjY3qPN50eSKzwuzEyQKy5TN2TiZdkIjos2L6A==",
+      "dependencies": {
+        "array-back": "^4.0.1",
+        "deep-extend": "~0.6.0",
+        "typical": "^5.2.0",
+        "wordwrapjs": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/table-layout/node_modules/array-back": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
+      "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/table-layout/node_modules/typical": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+      "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/table/node_modules/ajv": {
       "version": "8.11.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
@@ -15304,6 +16096,64 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.1.8.tgz",
+      "integrity": "sha512-YSneUCZSFDYMwk+TGq8qYFdCA3yfBRdBlS7txSq0LUmzyeqRe3a8fBQzbz9M3WS/iFT4BNf/nmw9mEzrnSaC0g==",
+      "dev": true,
+      "dependencies": {
+        "arg": "^5.0.2",
+        "chokidar": "^3.5.3",
+        "color-name": "^1.1.4",
+        "detective": "^5.2.1",
+        "didyoumean": "^1.2.2",
+        "dlv": "^1.1.3",
+        "fast-glob": "^3.2.11",
+        "glob-parent": "^6.0.2",
+        "is-glob": "^4.0.3",
+        "lilconfig": "^2.0.6",
+        "normalize-path": "^3.0.0",
+        "object-hash": "^3.0.0",
+        "picocolors": "^1.0.0",
+        "postcss": "^8.4.14",
+        "postcss-import": "^14.1.0",
+        "postcss-js": "^4.0.0",
+        "postcss-load-config": "^3.1.4",
+        "postcss-nested": "5.0.6",
+        "postcss-selector-parser": "^6.0.10",
+        "postcss-value-parser": "^4.2.0",
+        "quick-lru": "^5.1.1",
+        "resolve": "^1.22.1"
+      },
+      "bin": {
+        "tailwind": "lib/cli.js",
+        "tailwindcss": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=12.13.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.9"
+      }
+    },
+    "node_modules/tailwindcss/node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true
+    },
+    "node_modules/tailwindcss/node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/tar": {
@@ -15815,6 +16665,14 @@
       },
       "engines": {
         "node": ">=4.2.0"
+      }
+    },
+    "node_modules/typical": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
+      "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/uc.micro": {
@@ -16761,6 +17619,43 @@
         "node": ">=4"
       }
     },
+    "node_modules/vite": {
+      "version": "2.9.15",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.15.tgz",
+      "integrity": "sha512-fzMt2jK4vQ3yK56te3Kqpkaeq9DkcZfBbzHwYpobasvgYmP2SoAr6Aic05CsB4CzCZbsDv4sujX3pkEGhLabVQ==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.14.27",
+        "postcss": "^8.4.13",
+        "resolve": "^1.22.0",
+        "rollup": ">=2.59.0 <2.78.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": ">=12.2.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      },
+      "peerDependencies": {
+        "less": "*",
+        "sass": "*",
+        "stylus": "*"
+      },
+      "peerDependenciesMeta": {
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/vsce": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/vsce/-/vsce-2.10.0.tgz",
@@ -17212,6 +18107,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wordwrapjs": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-4.0.1.tgz",
+      "integrity": "sha512-kKlNACbvHrkpIw6oPeYDSmdCTu2hdMHoyXLTcUKala++lx5Y+wjJ/e474Jqv5abnVmwxw08DiTuHmw69lJGksA==",
+      "dependencies": {
+        "reduce-flatten": "^2.0.0",
+        "typical": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/wordwrapjs/node_modules/typical": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+      "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/workerpool": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.0.tgz",
@@ -17546,6 +18461,14 @@
         "duckdb": "0.4.1-dev1094.0"
       }
     },
+    "packages/malloy-db-duckdb-wasm": {
+      "name": "@malloydata/db-duckdb-wasm",
+      "version": "0.0.1",
+      "license": "GPL-2.0",
+      "dependencies": {
+        "@duckdb/duckdb-wasm": "1.16.0"
+      }
+    },
     "packages/malloy-db-postgres": {
       "name": "@malloydata/db-postgres",
       "version": "0.0.1",
@@ -17627,6 +18550,28 @@
       },
       "engines": {
         "vscode": "^1.63.0"
+      }
+    },
+    "testbed": {
+      "name": "vite-project",
+      "version": "0.0.0",
+      "extraneous": true,
+      "dependencies": {
+        "@duckdb/duckdb-wasm": "^1.16.0",
+        "highlight.js": "^11.6.0",
+        "prettier": "^2.6.2",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      },
+      "devDependencies": {
+        "@types/react": "^18.0.0",
+        "@types/react-dom": "^18.0.0",
+        "@vitejs/plugin-react": "^1.3.0",
+        "autoprefixer": "^10.4.7",
+        "postcss": "^8.4.14",
+        "tailwindcss": "^3.0.24",
+        "typescript": "^4.6.3",
+        "vite": "^2.9.9"
       }
     },
     "vscode-extension": {
@@ -18273,6 +19218,15 @@
         "@babel/helper-plugin-utils": "^7.8.0"
       }
     },
+    "@babel/plugin-syntax-jsx": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.18.6.tgz",
+      "integrity": "sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.18.6"
+      }
+    },
     "@babel/plugin-syntax-logical-assignment-operators": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
@@ -18334,6 +19288,46 @@
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-react-jsx": {
+      "version": "7.18.10",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.18.10.tgz",
+      "integrity": "sha512-gCy7Iikrpu3IZjYZolFE4M1Sm+nrh1/6za2Ewj77Z+XirT4TsbJcvOFOyF+fRPwU6AKKK136CZxx6L8AbSFG6A==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.18.6",
+        "@babel/helper-module-imports": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.18.9",
+        "@babel/plugin-syntax-jsx": "^7.18.6",
+        "@babel/types": "^7.18.10"
+      }
+    },
+    "@babel/plugin-transform-react-jsx-development": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.18.6.tgz",
+      "integrity": "sha512-SA6HEjwYFKF7WDjWcMcMGUimmw/nhNRDWxr+KaLSCrkD/LMDBvWRmHAYgE1HDeF8KUuI8OAu+RT6EOtKxSW2qA==",
+      "dev": true,
+      "requires": {
+        "@babel/plugin-transform-react-jsx": "^7.18.6"
+      }
+    },
+    "@babel/plugin-transform-react-jsx-self": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.18.6.tgz",
+      "integrity": "sha512-A0LQGx4+4Jv7u/tWzoJF7alZwnBDQd6cGLh9P+Ttk4dpiL+J5p7NSNv/9tlEFFJDq3kjxOavWmbm6t0Gk+A3Ig==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.18.6"
+      }
+    },
+    "@babel/plugin-transform-react-jsx-source": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.18.6.tgz",
+      "integrity": "sha512-utZmlASneDfdaMh0m/WausbjUjEdGrQJz0vFK93d7wD3xf5wBtX219+q6IlCNZeguIcxS2f/CvLZrlLSvSHQXw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.18.6"
       }
     },
     "@babel/runtime": {
@@ -18441,6 +19435,14 @@
             "@jridgewell/sourcemap-codec": "^1.4.10"
           }
         }
+      }
+    },
+    "@duckdb/duckdb-wasm": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@duckdb/duckdb-wasm/-/duckdb-wasm-1.16.0.tgz",
+      "integrity": "sha512-6jacKFUQEgfqF+rYyuIg/hwdSAxIfN4Xyl1cNBHqm4/V/C09JL07rx/ljeURvLVx/hWYD3IwyQAnLfxP/8o5Og==",
+      "requires": {
+        "apache-arrow": "^8.0.0"
       }
     },
     "@electron/get": {
@@ -18946,6 +19948,12 @@
         "duckdb": "0.4.1-dev1094.0"
       }
     },
+    "@malloydata/db-duckdb-wasm": {
+      "version": "file:packages/malloy-db-duckdb-wasm",
+      "requires": {
+        "@duckdb/duckdb-wasm": "1.16.0"
+      }
+    },
     "@malloydata/db-postgres": {
       "version": "file:packages/malloy-db-postgres",
       "requires": {
@@ -19132,6 +20140,16 @@
       "version": "2.11.6",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz",
       "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw=="
+    },
+    "@rollup/pluginutils": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
+      "integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
+      "dev": true,
+      "requires": {
+        "estree-walker": "^2.0.1",
+        "picomatch": "^2.2.2"
+      }
     },
     "@sideway/address": {
       "version": "4.1.4",
@@ -19388,6 +20406,16 @@
       "resolved": "https://registry.npmjs.org/@types/clone/-/clone-2.1.1.tgz",
       "integrity": "sha512-BZIU34bSYye0j/BFcPraiDZ5ka6MJADjcDVELGf7glr9K+iE8NYVjFslJFVWzskSxkLLyCrSPScE82/UUoBSvg=="
     },
+    "@types/command-line-args": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@types/command-line-args/-/command-line-args-5.2.0.tgz",
+      "integrity": "sha512-UuKzKpJJ/Ief6ufIaIzr3A/0XnluX7RvFgwkV89Yzvm77wCh1kFaFmqN8XEnGcN62EuHdedQjEMb8mYxFLGPyA=="
+    },
+    "@types/command-line-usage": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@types/command-line-usage/-/command-line-usage-5.0.2.tgz",
+      "integrity": "sha512-n7RlEEJ+4x4TS7ZQddTmNSxP+zziEG0TNsMfiRIxcIVXt71ENJ9ojeXmGO3wPoTdn7pJcU2xc3CJYMktNT6DPg=="
+    },
     "@types/debug": {
       "version": "4.1.7",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
@@ -19400,6 +20428,11 @@
       "version": "0.0.50",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz",
       "integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw=="
+    },
+    "@types/flatbuffers": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@types/flatbuffers/-/flatbuffers-1.10.0.tgz",
+      "integrity": "sha512-7btbphLrKvo5yl/5CC2OCxUSMx1wV1wvGT1qDXkSt7yi00/YW7E8k6qzXqJHsp+WU0eoG7r6MTQQXI9lIvd0qA=="
     },
     "@types/fs-extra": {
       "version": "9.0.13",
@@ -19571,6 +20604,11 @@
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
       "dev": true
+    },
+    "@types/pad-left": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@types/pad-left/-/pad-left-2.1.1.tgz",
+      "integrity": "sha512-Xd22WCRBydkGSApl5Bw0PhAOHKSVjNL3E3AwzKaps96IMraPqy5BvZIsBVK6JLwdybUzjHnuWVwpDd0JjTfHXA=="
     },
     "@types/parse-json": {
       "version": "4.0.0",
@@ -19813,6 +20851,22 @@
       "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
       "dev": true
     },
+    "@vitejs/plugin-react": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-1.3.2.tgz",
+      "integrity": "sha512-aurBNmMo0kz1O4qRoY+FM4epSA39y3ShWGuqfLRA/3z0oEJAdtoSfgA3aO98/PCCHAqMaduLxIxErWrVKIFzXA==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.17.10",
+        "@babel/plugin-transform-react-jsx": "^7.17.3",
+        "@babel/plugin-transform-react-jsx-development": "^7.16.7",
+        "@babel/plugin-transform-react-jsx-self": "^7.16.7",
+        "@babel/plugin-transform-react-jsx-source": "^7.16.7",
+        "@rollup/pluginutils": "^4.2.1",
+        "react-refresh": "^0.13.0",
+        "resolve": "^1.22.0"
+      }
+    },
     "@vscode/webview-ui-toolkit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@vscode/webview-ui-toolkit/-/webview-ui-toolkit-1.0.0.tgz",
@@ -19864,6 +20918,17 @@
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
       "requires": {}
+    },
+    "acorn-node": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/acorn-node/-/acorn-node-1.8.2.tgz",
+      "integrity": "sha512-8mt+fslDufLYntIoPAaIMUe/lrbrehIiwmR3t2k9LljIzoigEPF27eLk2hy8zSGzmR/ogr7zbRKINMo1u0yh5A==",
+      "dev": true,
+      "requires": {
+        "acorn": "^7.0.0",
+        "acorn-walk": "^7.0.0",
+        "xtend": "^4.0.2"
+      }
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -19945,6 +21010,36 @@
       "requires": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
+      }
+    },
+    "apache-arrow": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/apache-arrow/-/apache-arrow-8.0.0.tgz",
+      "integrity": "sha512-74wgHL9P+vgylNOhnLGw1meOQ1cbYyi+TXo1eDnQJ9g2Ly+k8novUWQIG5SIp6acnErhGRTsMJajwUh9x/ZbaQ==",
+      "requires": {
+        "@types/command-line-args": "5.2.0",
+        "@types/command-line-usage": "5.0.2",
+        "@types/flatbuffers": "*",
+        "@types/node": "^17.0.24",
+        "@types/pad-left": "2.1.1",
+        "command-line-args": "5.2.1",
+        "command-line-usage": "6.1.3",
+        "flatbuffers": "2.0.4",
+        "json-bignum": "^0.0.3",
+        "pad-left": "^2.1.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "17.0.45",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
+          "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw=="
+        },
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+        }
       }
     },
     "aproba": {
@@ -20077,6 +21172,11 @@
       "integrity": "sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==",
       "dev": true
     },
+    "array-back": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
+      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q=="
+    },
     "array-flat-polyfill": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/array-flat-polyfill/-/array-flat-polyfill-1.0.1.tgz",
@@ -20184,6 +21284,20 @@
       "resolved": "https://registry.npmjs.org/author-regex/-/author-regex-1.0.0.tgz",
       "integrity": "sha512-KbWgR8wOYRAPekEmMXrYYdc7BRyhn2Ftk7KWfMUnQ43hFdojWEFRxhhRUm3/OFEdPa1r0KAvTTg9YQK57xTe0g==",
       "devOptional": true
+    },
+    "autoprefixer": {
+      "version": "10.4.8",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.8.tgz",
+      "integrity": "sha512-75Jr6Q/XpTqEf6D2ltS5uMewJIx5irCU1oBYJrWjFenq/m12WRRrz6g15L1EIoYvPLXTbEry7rDOwrcYNj77xw==",
+      "dev": true,
+      "requires": {
+        "browserslist": "^4.21.3",
+        "caniuse-lite": "^1.0.30001373",
+        "fraction.js": "^4.2.0",
+        "normalize-range": "^0.1.2",
+        "picocolors": "^1.0.0",
+        "postcss-value-parser": "^4.2.0"
+      }
     },
     "available-typed-arrays": {
       "version": "1.0.5",
@@ -20644,6 +21758,12 @@
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "devOptional": true
     },
+    "camelcase-css": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "dev": true
+    },
     "camelize": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.0.tgz",
@@ -20994,6 +22114,89 @@
         "delayed-stream": "~1.0.0"
       }
     },
+    "command-line-args": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.2.1.tgz",
+      "integrity": "sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==",
+      "requires": {
+        "array-back": "^3.1.0",
+        "find-replace": "^3.0.0",
+        "lodash.camelcase": "^4.3.0",
+        "typical": "^4.0.0"
+      }
+    },
+    "command-line-usage": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-6.1.3.tgz",
+      "integrity": "sha512-sH5ZSPr+7UStsloltmDh7Ce5fb8XPlHyoPzTpyyMuYCtervL65+ubVZ6Q61cFtFl62UyJlc8/JwERRbAFPUqgw==",
+      "requires": {
+        "array-back": "^4.0.2",
+        "chalk": "^2.4.2",
+        "table-layout": "^1.0.2",
+        "typical": "^5.2.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "array-back": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
+          "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg=="
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        },
+        "typical": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+          "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg=="
+        }
+      }
+    },
     "commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -21226,6 +22429,12 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
       "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
+      "dev": true
+    },
+    "cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
       "dev": true
     },
     "cssom": {
@@ -21664,6 +22873,12 @@
         "isobject": "^3.0.1"
       }
     },
+    "defined": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+      "integrity": "sha512-Y2caI5+ZwS5c3RiNDJ6u53VhQHv+hHKwhkI1iHvceKUHw9Df6EK2zRLfjejRgMuCuxK7PfSWIMwWecceVvThjQ==",
+      "dev": true
+    },
     "delaunator": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-4.0.1.tgz",
@@ -21699,6 +22914,23 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
+    },
+    "detective": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/detective/-/detective-5.2.1.tgz",
+      "integrity": "sha512-v9XE1zRnz1wRtgurGu0Bs8uHKFSTdteYZNbIPFVhUZ39L/S79ppMpdmVOZAnoz1jfEFodc48n6MX483Xo3t1yw==",
+      "dev": true,
+      "requires": {
+        "acorn-node": "^1.8.2",
+        "defined": "^1.0.0",
+        "minimist": "^1.2.6"
+      }
+    },
+    "didyoumean": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
+      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+      "dev": true
     },
     "diff": {
       "version": "5.0.0",
@@ -21751,6 +22983,12 @@
       "requires": {
         "path-type": "^4.0.0"
       }
+    },
+    "dlv": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true
     },
     "doctrine": {
       "version": "3.0.0",
@@ -22719,6 +23957,12 @@
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true
     },
+    "estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true
+    },
     "esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -23143,6 +24387,14 @@
         "to-regex-range": "^5.0.1"
       }
     },
+    "find-replace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
+      "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
+      "requires": {
+        "array-back": "^3.0.1"
+      }
+    },
     "find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -23168,6 +24420,11 @@
         "flatted": "^3.1.0",
         "rimraf": "^3.0.2"
       }
+    },
+    "flatbuffers": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-2.0.4.tgz",
+      "integrity": "sha512-4rUFVDPjSoP0tOII34oQf+72NKU7E088U5oX7kwICahft0UB2kOQ9wUzzCp+OHxByERIfxRDCgX5mP8Pjkfl0g=="
     },
     "flatted": {
       "version": "3.2.6",
@@ -23242,6 +24499,12 @@
         "combined-stream": "^1.0.8",
         "mime-types": "^2.1.12"
       }
+    },
+    "fraction.js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.2.0.tgz",
+      "integrity": "sha512-MhLuK+2gUcnZe8ZHlaaINnQLl0xRIGRfcGk2yl8xoQAfHrSsL3rYu6FCmBdkdbhc9EPlwyGHewaRsvwRMJtAlA==",
+      "dev": true
     },
     "fragment-cache": {
       "version": "0.2.1",
@@ -23936,6 +25199,11 @@
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
+    },
+    "highlight.js": {
+      "version": "11.6.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.6.0.tgz",
+      "integrity": "sha512-ig1eqDzJaB0pqEvlPVIpSSyMaO92bH1N2rJpLMN/nX396wTpDA4Eq0uK+7I/2XG17pFaaKE0kjV/XPeGt7Evjw=="
     },
     "hoist-non-react-statics": {
       "version": "3.3.2",
@@ -25660,6 +26928,11 @@
         "bignumber.js": "^9.0.0"
       }
     },
+    "json-bignum": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/json-bignum/-/json-bignum-0.0.3.tgz",
+      "integrity": "sha512-2WHyXj3OfHSgNyuzDbSxI1w2jgw5gkWSWhS7Qg4bWXx1nLk3jnbwfUeS0PSba3IzpTUWdHxBieELUzXRjQB2zg=="
+    },
     "json-buffer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
@@ -25842,6 +27115,12 @@
         "type-check": "~0.4.0"
       }
     },
+    "lilconfig": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.6.tgz",
+      "integrity": "sha512-9JROoBW7pobfsx+Sq2JsASvCo6Pfo6WWoUW79HuB1BCoBXD4PLWJPqDF6fNj67pqBYTbAHkE57M1kS/+L1neOg==",
+      "dev": true
+    },
     "lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -25911,6 +27190,11 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
     },
     "lodash.defaults": {
       "version": "4.2.0",
@@ -26072,6 +27356,72 @@
       "requires": {
         "@malloydata/db-bigquery": "*",
         "@malloydata/malloy": "*"
+      }
+    },
+    "malloy-demo-browser": {
+      "version": "file:demo/malloy-demo-browser",
+      "requires": {
+        "@duckdb/duckdb-wasm": "^1.16.0",
+        "@malloydata/db-duckdb-wasm": "^0.0.1",
+        "@types/react": "^18.0.0",
+        "@types/react-dom": "^18.0.0",
+        "@vitejs/plugin-react": "^1.3.0",
+        "autoprefixer": "^10.4.7",
+        "highlight.js": "^11.6.0",
+        "postcss": "^8.4.14",
+        "prettier": "^2.6.2",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0",
+        "tailwindcss": "^3.0.24",
+        "typescript": "^4.6.3",
+        "vite": "^2.9.9"
+      },
+      "dependencies": {
+        "@types/react": {
+          "version": "18.0.17",
+          "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.17.tgz",
+          "integrity": "sha512-38ETy4tL+rn4uQQi7mB81G7V1g0u2ryquNmsVIOKUAEIDK+3CUjZ6rSRpdvS99dNBnkLFL83qfmtLacGOTIhwQ==",
+          "dev": true,
+          "requires": {
+            "@types/prop-types": "*",
+            "@types/scheduler": "*",
+            "csstype": "^3.0.2"
+          }
+        },
+        "@types/react-dom": {
+          "version": "18.0.6",
+          "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.6.tgz",
+          "integrity": "sha512-/5OFZgfIPSwy+YuIBP/FgJnQnsxhZhjjrnxudMddeblOouIodEQ75X14Rr4wGSG/bknL+Omy9iWlLo1u/9GzAA==",
+          "dev": true,
+          "requires": {
+            "@types/react": "*"
+          }
+        },
+        "react": {
+          "version": "18.2.0",
+          "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+          "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+          "requires": {
+            "loose-envify": "^1.1.0"
+          }
+        },
+        "react-dom": {
+          "version": "18.2.0",
+          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
+          "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "scheduler": "^0.23.0"
+          }
+        },
+        "scheduler": {
+          "version": "0.23.0",
+          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
+          "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
+          "requires": {
+            "loose-envify": "^1.1.0"
+          }
+        }
       }
     },
     "map-cache": {
@@ -27203,6 +28553,12 @@
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true
     },
+    "normalize-range": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+      "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
+      "dev": true
+    },
     "normalize-url": {
       "version": "4.5.1",
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
@@ -27335,6 +28691,12 @@
           }
         }
       }
+    },
+    "object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true
     },
     "object-inspect": {
       "version": "1.12.2",
@@ -27480,6 +28842,14 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-1.0.0.tgz",
       "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ=="
+    },
+    "pad-left": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pad-left/-/pad-left-2.1.0.tgz",
+      "integrity": "sha512-HJxs9K9AztdIQIAIa/OIazRAUW/L6B9hbQDxO4X07roW3eo9XqZc2ur9bn1StH9CnbbI9EgvejHQX7CBpCF1QA==",
+      "requires": {
+        "repeat-string": "^1.5.4"
+      }
     },
     "parent-module": {
       "version": "1.0.1",
@@ -27765,6 +29135,74 @@
       "integrity": "sha512-xTgYBc3fuo7Yt7JbiuFxSYGToMoz8fLoE6TC9Wx1P/u+LfeThMOAqmuyECnlBaaJb+u1m9hHiXUEtwW4OzfUJg==",
       "dev": true
     },
+    "postcss": {
+      "version": "8.4.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.16.tgz",
+      "integrity": "sha512-ipHE1XBvKzm5xI7hiHCZJCSugxvsdq2mPnsq5+UF+VHCjiBvtDrlxJfMBToWaP9D5XlgNmcFGqoHmUn0EYEaRQ==",
+      "dev": true,
+      "requires": {
+        "nanoid": "^3.3.4",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "dependencies": {
+        "nanoid": {
+          "version": "3.3.4",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+          "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+          "dev": true
+        }
+      }
+    },
+    "postcss-import": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-14.1.0.tgz",
+      "integrity": "sha512-flwI+Vgm4SElObFVPpTIT7SU7R3qk2L7PyduMcokiaVKuWv9d/U+Gm/QAd8NDLuykTWTkcrjOeD2Pp1rMeBTGw==",
+      "dev": true,
+      "requires": {
+        "postcss-value-parser": "^4.0.0",
+        "read-cache": "^1.0.0",
+        "resolve": "^1.1.7"
+      }
+    },
+    "postcss-js": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.0.0.tgz",
+      "integrity": "sha512-77QESFBwgX4irogGVPgQ5s07vLvFqWr228qZY+w6lW599cRlK/HmnlivnnVUxkjHnCu4J16PDMHcH+e+2HbvTQ==",
+      "dev": true,
+      "requires": {
+        "camelcase-css": "^2.0.1"
+      }
+    },
+    "postcss-load-config": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-3.1.4.tgz",
+      "integrity": "sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==",
+      "dev": true,
+      "requires": {
+        "lilconfig": "^2.0.5",
+        "yaml": "^1.10.2"
+      }
+    },
+    "postcss-nested": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-5.0.6.tgz",
+      "integrity": "sha512-rKqm2Fk0KbA8Vt3AdGN0FB9OBOMDVajMG6ZCf/GoHgdxUJ4sBFp0A/uMIRm+MJUdo33YXEtjqIz8u7DAp8B7DA==",
+      "dev": true,
+      "requires": {
+        "postcss-selector-parser": "^6.0.6"
+      }
+    },
+    "postcss-selector-parser": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "dev": true,
+      "requires": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      }
+    },
     "postcss-value-parser": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
@@ -27827,8 +29265,7 @@
     "prettier": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
-      "dev": true
+      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g=="
     },
     "prettier-linter-helpers": {
       "version": "1.0.0",
@@ -27953,6 +29390,12 @@
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true
     },
+    "quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "dev": true
+    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -28055,6 +29498,12 @@
         "match-sorter": "^6.0.2"
       }
     },
+    "react-refresh": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.13.0.tgz",
+      "integrity": "sha512-XP8A9BT0CpRBD+NYLLeIhld/RqG9+gktUjW1FkE+Vm7OCinbG1SshcK5tb9ls4kzvjZr9mOQc7HYgBngEyPAXg==",
+      "dev": true
+    },
     "read": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
@@ -28062,6 +29511,23 @@
       "dev": true,
       "requires": {
         "mute-stream": "~0.0.4"
+      }
+    },
+    "read-cache": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "dev": true,
+      "requires": {
+        "pify": "^2.3.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+          "dev": true
+        }
       }
     },
     "read-pkg": {
@@ -28151,6 +29617,11 @@
         "picomatch": "^2.2.1"
       }
     },
+    "reduce-flatten": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-2.0.0.tgz",
+      "integrity": "sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w=="
+    },
     "regenerator-runtime": {
       "version": "0.13.9",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
@@ -28233,8 +29704,7 @@
     "repeat-string": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
-      "dev": true
+      "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w=="
     },
     "request": {
       "version": "2.88.2",
@@ -28407,6 +29877,15 @@
           "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
           "optional": true
         }
+      }
+    },
+    "rollup": {
+      "version": "2.77.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.77.3.tgz",
+      "integrity": "sha512-/qxNTG7FbmefJWoeeYJFbHehJ2HNWnjkAFRKzWN/45eNBBF/r8lo992CwcJXEzyVxs5FmfId+vTSTQDb+bxA+g==",
+      "dev": true,
+      "requires": {
+        "fsevents": "~2.3.2"
       }
     },
     "rsvp": {
@@ -29070,6 +30549,12 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true
     },
+    "source-map-js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+      "dev": true
+    },
     "source-map-resolve": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
@@ -29552,6 +31037,76 @@
         }
       }
     },
+    "table-layout": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-1.0.2.tgz",
+      "integrity": "sha512-qd/R7n5rQTRFi+Zf2sk5XVVd9UQl6ZkduPFC3S7WEGJAmetDTjY3qPN50eSKzwuzEyQKy5TN2TiZdkIjos2L6A==",
+      "requires": {
+        "array-back": "^4.0.1",
+        "deep-extend": "~0.6.0",
+        "typical": "^5.2.0",
+        "wordwrapjs": "^4.0.0"
+      },
+      "dependencies": {
+        "array-back": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
+          "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg=="
+        },
+        "typical": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+          "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg=="
+        }
+      }
+    },
+    "tailwindcss": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.1.8.tgz",
+      "integrity": "sha512-YSneUCZSFDYMwk+TGq8qYFdCA3yfBRdBlS7txSq0LUmzyeqRe3a8fBQzbz9M3WS/iFT4BNf/nmw9mEzrnSaC0g==",
+      "dev": true,
+      "requires": {
+        "arg": "^5.0.2",
+        "chokidar": "^3.5.3",
+        "color-name": "^1.1.4",
+        "detective": "^5.2.1",
+        "didyoumean": "^1.2.2",
+        "dlv": "^1.1.3",
+        "fast-glob": "^3.2.11",
+        "glob-parent": "^6.0.2",
+        "is-glob": "^4.0.3",
+        "lilconfig": "^2.0.6",
+        "normalize-path": "^3.0.0",
+        "object-hash": "^3.0.0",
+        "picocolors": "^1.0.0",
+        "postcss": "^8.4.14",
+        "postcss-import": "^14.1.0",
+        "postcss-js": "^4.0.0",
+        "postcss-load-config": "^3.1.4",
+        "postcss-nested": "5.0.6",
+        "postcss-selector-parser": "^6.0.10",
+        "postcss-value-parser": "^4.2.0",
+        "quick-lru": "^5.1.1",
+        "resolve": "^1.22.1"
+      },
+      "dependencies": {
+        "arg": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+          "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+          "dev": true
+        },
+        "glob-parent": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+          "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.3"
+          }
+        }
+      }
+    },
     "tar": {
       "version": "6.1.11",
       "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
@@ -29926,6 +31481,11 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
       "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
       "dev": true
+    },
+    "typical": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
+      "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw=="
     },
     "uc.micro": {
       "version": "1.0.6",
@@ -30735,6 +32295,19 @@
         "unist-util-stringify-position": "^3.0.0"
       }
     },
+    "vite": {
+      "version": "2.9.15",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.15.tgz",
+      "integrity": "sha512-fzMt2jK4vQ3yK56te3Kqpkaeq9DkcZfBbzHwYpobasvgYmP2SoAr6Aic05CsB4CzCZbsDv4sujX3pkEGhLabVQ==",
+      "dev": true,
+      "requires": {
+        "esbuild": "^0.14.27",
+        "fsevents": "~2.3.2",
+        "postcss": "^8.4.13",
+        "resolve": "^1.22.0",
+        "rollup": ">=2.59.0 <2.78.0"
+      }
+    },
     "vsce": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/vsce/-/vsce-2.10.0.tgz",
@@ -31302,6 +32875,22 @@
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
       "devOptional": true
+    },
+    "wordwrapjs": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-4.0.1.tgz",
+      "integrity": "sha512-kKlNACbvHrkpIw6oPeYDSmdCTu2hdMHoyXLTcUKala++lx5Y+wjJ/e474Jqv5abnVmwxw08DiTuHmw69lJGksA==",
+      "requires": {
+        "reduce-flatten": "^2.0.0",
+        "typical": "^5.2.0"
+      },
+      "dependencies": {
+        "typical": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+          "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg=="
+        }
+      }
     },
     "workerpool": {
       "version": "6.2.0",

--- a/packages/malloy-db-duckdb-wasm/package.json
+++ b/packages/malloy-db-duckdb-wasm/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@malloydata/db-duckdb-wasm",
+  "version": "0.0.1",
+  "license": "GPL-2.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "lint": "eslint '**/*.ts{,x}'",
+    "lint-fix": "eslint '**/*.ts{,x}' --fix",
+    "test": "jest --config=../../jest.config.js",
+    "build": "tsc --build",
+    "malloyc": "ts-node ../../scripts/malloy-to-json"
+  },
+  "dependencies": {
+    "@duckdb/duckdb-wasm": "1.16.0"
+  }
+}

--- a/packages/malloy-db-duckdb-wasm/src/duckdb.d.ts
+++ b/packages/malloy-db-duckdb-wasm/src/duckdb.d.ts
@@ -1,0 +1,16 @@
+declare module "duckdb" {
+  /**
+   * Scalar result value type
+   */
+  type Scalar = boolean | number | string | null;
+
+  /**
+   * All result value types
+   */
+  type Value = Scalar | Record<string, Value> | Array<Value> | null;
+
+  /**
+   * Result row
+   */
+  type Row = Record<string, Value>;
+}

--- a/packages/malloy-db-duckdb-wasm/src/duckdb_wasm_connection.ts
+++ b/packages/malloy-db-duckdb-wasm/src/duckdb_wasm_connection.ts
@@ -1,0 +1,440 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ */
+import * as duckdb from "@duckdb/duckdb-wasm";
+import {
+  AtomicFieldTypeInner,
+  Connection,
+  FieldTypeDef,
+  MalloyQueryData,
+  NamedStructDefs,
+  parseTableURL,
+  PersistSQLResults,
+  PooledConnection,
+  QueryDataRow,
+  SQLBlock,
+  StructDef,
+} from "@malloydata/malloy/src";
+import { RunSQLOptions } from "@malloydata/malloy/src/malloy";
+import {
+  FetchSchemaAndRunSimultaneously,
+  FetchSchemaAndRunStreamSimultaneously,
+  StreamingConnection,
+} from "@malloydata/malloy/src/runtime_types";
+import { Row } from "duckdb";
+
+// TODO(charlie): Come up with a common DuckDB and DuckDB-Wasm abstraction to DRY up the code here.
+const duckDBToMalloyTypes: { [key: string]: AtomicFieldTypeInner } = {
+  BIGINT: "number",
+  DOUBLE: "number",
+  VARCHAR: "string",
+  DATE: "date",
+  TIMESTAMP: "timestamp",
+  TIME: "string",
+  DECIMAL: "number",
+  BOOLEAN: "boolean",
+  INTEGER: "number",
+};
+
+export class DuckDBWasmConnection
+  implements Connection, PersistSQLResults, StreamingConnection
+{
+  protected connection?: duckdb.AsyncDuckDBConnection;
+  protected database?: duckdb.AsyncDuckDB;
+  protected isSetup = false;
+
+  constructor(public readonly name: string) {}
+
+  get dialectName(): string {
+    return "duckdb";
+  }
+
+  public isPool(): this is PooledConnection {
+    return false;
+  }
+
+  public canPersist(): this is PersistSQLResults {
+    return true;
+  }
+
+  public async setup(): Promise<void> {
+    if (!this.isSetup) {
+      const JSDELIVR_BUNDLES = duckdb.getJsDelivrBundles();
+
+      // Select a bundle based on browser checks
+      const bundle = await duckdb.selectBundle(JSDELIVR_BUNDLES);
+
+      const worker_url = URL.createObjectURL(
+        new Blob([`importScripts("${bundle.mainWorker!}");`], {
+          type: "text/javascript",
+        })
+      );
+
+      // Instantiate the asynchronus version of DuckDB-wasm
+      const worker = new Worker(worker_url);
+      const logger = new duckdb.ConsoleLogger();
+      this.database = new duckdb.AsyncDuckDB(logger, worker);
+      await this.database.instantiate(bundle.mainModule, bundle.pthreadWorker);
+      URL.revokeObjectURL(worker_url);
+
+      this.connection = await this.database.connect();
+
+      // TODO: This is where we will load extensions once we figure
+      // out how to better support them.
+      // await this.runDuckDBQuery("INSTALL 'json'");
+      // await this.runDuckDBQuery("LOAD 'json'");
+      // await this.runDuckDBQuery("INSTALL 'httpfs'");
+      // await this.runDuckDBQuery("LOAD 'httpfs'");
+      //   await this.runDuckDBQuery("DROP MACRO sum_distinct");
+      //   try {
+      //     await this.runDuckDBQuery(
+      //       `
+      //       create macro sum_distinct(l) as  (
+      //         select sum(x.val) as value FROM (select unnest(l)) x
+      //       )
+      //       `
+      //     );
+      //   } catch (e) {}
+    }
+    this.isSetup = true;
+  }
+
+  protected async runDuckDBQuery(
+    sql: string
+  ): Promise<{ rows: Row[]; totalRows: number }> {
+    return new Promise((resolve, reject) => {
+      if (this.connection == null) {
+        throw new Error("Expected connection to be set.");
+      }
+      return this.connection
+        .query(sql)
+        .then((res) => {
+          const rows = JSON.parse(
+            JSON.stringify(res.toArray(), (key, value) =>
+              typeof value === "bigint" ? value.toString() : value
+            )
+          );
+          resolve({ rows, totalRows: rows.length });
+        })
+        .catch(reject);
+    });
+  }
+
+  public async runRawSQL(
+    sql: string
+  ): Promise<{ rows: Row[]; totalRows: number }> {
+    await this.setup();
+    return this.runDuckDBQuery(sql);
+  }
+
+  public async runSQL(
+    sql: string,
+    options: RunSQLOptions = {}
+  ): Promise<MalloyQueryData> {
+    const rowLimit = options.rowLimit ?? 10;
+
+    const statements = sql.split("-- hack: split on this");
+
+    while (statements.length > 1) {
+      await this.runRawSQL(statements[0]);
+      statements.shift();
+    }
+
+    const retVal = await this.runRawSQL(statements[0]);
+    let result = retVal.rows;
+    if (result.length > rowLimit) {
+      result = result.slice(0, rowLimit);
+    }
+    return { rows: result, totalRows: result.length };
+  }
+
+  public async *runSQLStream(
+    sql: string,
+    _options: RunSQLOptions = {}
+  ): AsyncIterableIterator<QueryDataRow> {
+    await this.setup();
+
+    if (this.connection == null) {
+      throw new Error("Expected connection to be set.");
+    }
+
+    const statements = sql.split("-- hack: split on this");
+
+    while (statements.length > 1) {
+      await this.runDuckDBQuery(statements[0]);
+      statements.shift();
+    }
+
+    for await (const batch of await this.connection.send(statements[0])) {
+      for (const row of batch) {
+        yield row;
+      }
+    }
+  }
+
+  public async runSQLBlockAndFetchResultSchema(
+    sqlBlock: SQLBlock
+  ): Promise<{ data: MalloyQueryData; schema: StructDef }> {
+    const data = await this.runSQL(sqlBlock.select);
+    const schema = (await this.fetchSchemaForSQLBlocks([sqlBlock])).schemas[
+      sqlBlock.name
+    ];
+    return { data, schema };
+  }
+
+  private async getSQLBlockSchema(sqlRef: SQLBlock): Promise<StructDef> {
+    const structDef: StructDef = {
+      type: "struct",
+      dialect: "duckdb",
+      name: sqlRef.name,
+      structSource: {
+        type: "sql",
+        method: "subquery",
+        sqlBlock: sqlRef,
+      },
+      structRelationship: {
+        type: "basetable",
+        connectionName: this.name,
+      },
+      fields: [],
+    };
+
+    await this.schemaFromQuery(
+      `DESCRIBE SELECT * FROM (${sqlRef.select})`,
+      structDef
+    );
+    return structDef;
+  }
+
+  /**
+   * Split's a structs columns declaration into individual columns
+   * to be fed back into fillStructDefFromTypeMap(). Handles commas
+   * within nested STRUCT() declarations.
+   *
+   * (https://github.com/looker-open-source/malloy/issues/635)
+   *
+   * @param s struct's column declaration
+   * @returns Array of column type declarations
+   */
+  private splitColumns(s: string) {
+    const columns = [];
+    let parens = 0;
+    let column = "";
+    let eatSpaces = true;
+    for (let idx = 0; idx < s.length; idx++) {
+      const c = s.charAt(idx);
+      if (eatSpaces && c === " ") {
+        // Eat space
+      } else {
+        eatSpaces = false;
+        if (!parens && c === ",") {
+          columns.push(column);
+          column = "";
+          eatSpaces = true;
+        } else {
+          column += c;
+        }
+        if (c === "(") {
+          parens += 1;
+        } else if (c === ")") {
+          parens -= 1;
+        }
+      }
+    }
+    columns.push(column);
+    return columns;
+  }
+
+  private stringToTypeMap(s: string): { [name: string]: string } {
+    const ret: { [name: string]: string } = {};
+    const columns = this.splitColumns(s);
+    for (const c of columns) {
+      //const [name, type] = c.split(" ", 1);
+      const columnMatch = c.match(/^(?<name>[^\s]+) (?<type>.*)$/);
+      if (columnMatch && columnMatch.groups) {
+        ret[columnMatch.groups["name"]] = columnMatch.groups["type"];
+      } else {
+        throw new Error(`Badly form Structure definition ${s}`);
+      }
+    }
+    return ret;
+  }
+
+  private fillStructDefFromTypeMap(
+    structDef: StructDef,
+    typeMap: { [name: string]: string }
+  ) {
+    for (const name in typeMap) {
+      let duckDBType = typeMap[name];
+      // Remove DECIMAL(x,y) precision to simplify lookup
+      duckDBType = duckDBType.replace(/^DECIMAL\(\d+,\d+\)/g, "DECIMAL");
+      let malloyType = duckDBToMalloyTypes[duckDBType];
+      const arrayMatch = duckDBType.match(/(?<duckDBType>.*)\[\]$/);
+      if (arrayMatch && arrayMatch.groups) {
+        duckDBType = arrayMatch.groups["duckDBType"];
+      }
+      const structMatch = duckDBType.match(/^STRUCT\((?<fields>.*)\)$/);
+      if (structMatch && structMatch.groups) {
+        const newTypeMap = this.stringToTypeMap(structMatch.groups["fields"]);
+        const innerStructDef: StructDef = {
+          type: "struct",
+          name,
+          dialect: this.dialectName,
+          structSource: { type: arrayMatch ? "nested" : "inline" },
+          structRelationship: {
+            type: arrayMatch ? "nested" : "inline",
+            field: name,
+            isArray: false,
+          },
+          fields: [],
+        };
+        this.fillStructDefFromTypeMap(innerStructDef, newTypeMap);
+        structDef.fields.push(innerStructDef);
+      } else {
+        if (arrayMatch) {
+          malloyType = duckDBToMalloyTypes[duckDBType];
+          const innerStructDef: StructDef = {
+            type: "struct",
+            name,
+            dialect: this.dialectName,
+            structSource: { type: "nested" },
+            structRelationship: { type: "nested", field: name, isArray: true },
+            fields: [{ type: malloyType, name: "value" } as FieldTypeDef],
+          };
+          structDef.fields.push(innerStructDef);
+        } else {
+          if (malloyType !== undefined) {
+            structDef.fields.push({
+              type: malloyType,
+              name,
+            });
+          } else {
+            throw new Error(`unknown duckdb type ${duckDBType}`);
+          }
+        }
+      }
+    }
+  }
+
+  private async schemaFromQuery(
+    infoQuery: string,
+    structDef: StructDef
+  ): Promise<void> {
+    const typeMap: { [key: string]: string } = {};
+
+    const result = await this.runRawSQL(infoQuery);
+    for (const row of result.rows) {
+      typeMap[row["column_name"] as string] = row["column_type"] as string;
+    }
+    this.fillStructDefFromTypeMap(structDef, typeMap);
+  }
+
+  public async fetchSchemaForSQLBlocks(sqlRefs: SQLBlock[]): Promise<{
+    schemas: Record<string, StructDef>;
+    errors: Record<string, string>;
+  }> {
+    const schemas: NamedStructDefs = {};
+    const errors: { [name: string]: string } = {};
+
+    for (const sqlRef of sqlRefs) {
+      try {
+        schemas[sqlRef.name] = await this.getSQLBlockSchema(sqlRef);
+      } catch (error) {
+        errors[sqlRef.name] = error;
+      }
+    }
+    return { schemas, errors };
+  }
+
+  public async fetchSchemaForTables(tables: string[]): Promise<{
+    schemas: Record<string, StructDef>;
+    errors: Record<string, string>;
+  }> {
+    const schemas: NamedStructDefs = {};
+    const errors: { [name: string]: string } = {};
+
+    for (const tableURL of tables) {
+      try {
+        schemas[tableURL] = await this.getTableSchema(tableURL);
+      } catch (error) {
+        errors[tableURL] = error.toString();
+      }
+    }
+    return { schemas, errors };
+  }
+
+  private async getTableSchema(tableURL: string): Promise<StructDef> {
+    const { tablePath: tableName } = parseTableURL(tableURL);
+    const structDef: StructDef = {
+      type: "struct",
+      name: tableName,
+      dialect: "duckdb",
+      structSource: { type: "table" },
+      structRelationship: {
+        type: "basetable",
+        connectionName: this.name,
+      },
+      fields: [],
+    };
+
+    // const { tablePath: tableName } = parseTableURL(tableURL);
+    // const [schema, table] = tableName.split(".");
+    // if (table === undefined) {
+    //   throw new Error("Default schema not yet supported in DuckDB");
+    // }
+    // const infoQuery = `
+    //   SELECT column_name, data_type FROM information_schema.columns
+    //   WHERE table_name = '${table}'
+    //     AND table_schema = '${schema}'
+    // `;
+
+    const infoQuery = `DESCRIBE SELECT * FROM ${
+      tableName.match(/\//) ? `'${tableName}'` : tableName
+    };`;
+    await this.schemaFromQuery(infoQuery, structDef);
+    return structDef;
+  }
+
+  canFetchSchemaAndRunSimultaneously(): this is FetchSchemaAndRunSimultaneously {
+    return false;
+  }
+
+  canStream(): this is StreamingConnection {
+    return true;
+  }
+
+  canFetchSchemaAndRunStreamSimultaneously(): this is FetchSchemaAndRunStreamSimultaneously {
+    return false;
+  }
+
+  public async test(): Promise<void> {
+    await this.runRawSQL("SELECT 1");
+  }
+
+  public async manifestTemporaryTable(sqlCommand: string): Promise<string> {
+    const hashBuffer = await crypto.subtle.digest(
+      "SHA-256",
+      new TextEncoder().encode(sqlCommand)
+    );
+    const hashArray = Array.from(new Uint8Array(hashBuffer));
+    const hashHex = hashArray
+      .map((b) => b.toString(16).padStart(2, "0"))
+      .join("");
+
+    const tableName = `tt${hashHex}`;
+
+    const cmd = `CREATE TEMPORARY TABLE IF NOT EXISTS ${tableName} AS (${sqlCommand});`;
+    // console.log(cmd);
+    await this.runRawSQL(cmd);
+    return tableName;
+  }
+}

--- a/packages/malloy-db-duckdb-wasm/src/index.ts
+++ b/packages/malloy-db-duckdb-wasm/src/index.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ */
+
+export { DuckDBWasmConnection } from "./duckdb_wasm_connection";

--- a/packages/malloy-db-duckdb-wasm/tsconfig.json
+++ b/packages/malloy-db-duckdb-wasm/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.packages.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "composite": true
+  },
+  "references": [
+    {
+      "path": "../malloy"
+    }
+  ]
+}

--- a/packages/malloy/src/malloy.ts
+++ b/packages/malloy/src/malloy.ts
@@ -727,11 +727,15 @@ export function parseTableURL(tableURL: string): {
   connectionName?: string;
   tablePath: string;
 } {
-  const [firstPart, secondPart] = tableURL.split(":");
-  if (secondPart) {
-    return { connectionName: firstPart, tablePath: secondPart };
+  if (tableURL.startsWith("https://")) {
+    return { tablePath: tableURL };
+  }
+
+  const [head, ...tail] = tableURL.split(":");
+  if (tail.length > 0) {
+    return { connectionName: head, tablePath: tail.join(":") };
   } else {
-    return { tablePath: firstPart };
+    return { tablePath: head };
   }
 }
 


### PR DESCRIPTION
# Summary

In `malloy/demo/malloy-demo-browser`, run: `npm i && npm run dev`.

Navigate to [http://localhost:3000/](http://localhost:3000/):

<img width="1624" alt="Screen Shot 2022-08-26 at 6 40 40 PM" src="https://user-images.githubusercontent.com/1309177/186999586-7ff83210-c5dd-4e04-89de-a016908563ab.png">
